### PR TITLE
feat(logger): 增加环境变量注入功能并优化日志字段处理

### DIFF
--- a/logger/fields.go
+++ b/logger/fields.go
@@ -60,6 +60,7 @@ type Fields interface {
 	WithService(service string) Fields
 	WithCallTime(callTime time.Time) Fields
 	WithBaseFields(base Fields) Fields
+	WithAttachFields(attach Fields) Fields
 }
 
 type fields struct {
@@ -159,6 +160,30 @@ func (f *fields) WithBaseFields(base Fields) Fields {
 	f.message = entry.Message
 	f.data = entry.Data
 	f.extra = entry.Extra
+	return f
+}
+
+func (f *fields) WithAttachFields(attach Fields) Fields {
+	entry := attach.Export()
+	if entry.Level != "" {
+		f.level = Level(entry.Level)
+	}
+	if entry.Service != "" {
+		f.service = entry.Service
+	}
+	if entry.Message != "" {
+		f.message = entry.Message
+	}
+	if entry.Data != nil {
+		f.data = entry.Data
+	}
+	if f.extra == nil {
+		f.extra = map[string]any{}
+	}
+	for k, v := range entry.Extra {
+		f.extra[k] = v
+	}
+
 	return f
 }
 

--- a/logger/fields.go
+++ b/logger/fields.go
@@ -75,7 +75,7 @@ type fields struct {
 
 // init 初始化日志字段
 func (f *fields) init(ctx context.Context) Fields {
-	f.file, f.ctx, f.level = trace.Caller(2), trace.FromContext(ctx), LevelInfo
+	f.file, f.ctx, f.level = trace.Caller(1), trace.FromContext(ctx), LevelInfo
 
 	return f
 }

--- a/logger/fields.go
+++ b/logger/fields.go
@@ -194,16 +194,3 @@ func NewFields(ctx ...context.Context) Fields {
 
 	return (&fields{}).init(context.Background())
 }
-
-func NewFieldsFromEntry(entry *Entry) Fields {
-	return &fields{
-		ctx:      trace.NewContextWithTid(entry.TraceID),
-		level:    Level(entry.Level),
-		file:     entry.File,
-		service:  entry.Service,
-		message:  entry.Message,
-		data:     entry.Data,
-		extra:    entry.Extra,
-		callTime: entry.CallTime,
-	}
-}

--- a/logger/options.go
+++ b/logger/options.go
@@ -43,3 +43,17 @@ func WithHookOpts(hook func(Fields), levels ...Level) Option {
 		}
 	}
 }
+
+func WithAttachFields(fields Fields) Option {
+	return func(logger *customLogger) {
+		if fields == nil {
+			return
+		}
+		if logger.attach == nil {
+			logger.attach = fields
+			return
+		}
+
+		logger.attach = logger.attach.WithAttachFields(fields)
+	}
+}

--- a/logger/unit_test.go
+++ b/logger/unit_test.go
@@ -1,9 +1,11 @@
 package logger
 
 import (
-	"github.com/alioth-center/infrastructure/trace"
+	"os"
 	"testing"
 	"time"
+
+	"github.com/alioth-center/infrastructure/trace"
 )
 
 func TestCustom(t *testing.T) {
@@ -54,4 +56,15 @@ func TestWriter(t *testing.T) {
 	writer = NewTimeBasedRotationFileWriter("./", func(time time.Time) (_ string) { return "test_timed.jsonl" })
 	writer.Write([]byte("hello world"))
 	writer.Close()
+}
+
+func TestFields(t *testing.T) {
+	fields := NewFields()
+	fields = fields.WithAttachFields(NewFields().WithMessage("test").WithService("test").WithData(map[string]any{"foo": "bar"}).WithField("field", "value").WithCallTime(time.Now()).WithTraceID("test").WithCallTime(time.Time{}))
+
+	os.Setenv(serviceEnvKey, "ac_testing")
+	os.Setenv(extraFieldsKey, "KEY1,KEY2")
+	os.Setenv("KEY1", "VALUE1")
+	os.Setenv("KEY2", "VALUE2")
+	NewCustomLoggerWithOpts().Info(NewFields().WithMessage("test"))
 }

--- a/logger/unit_test.go
+++ b/logger/unit_test.go
@@ -14,7 +14,7 @@ func TestCustom(t *testing.T) {
 
 func TestLoggerFunction(t *testing.T) {
 	ctx := trace.NewContext()
-	base := NewFields(ctx).WithMessage("test").WithData(map[string]any{"foo": "bar", "nav": 0.1}).WithField("field", "value").WithCallTime(time.Now()).WithService("testing").WithTraceID(trace.GetTid(ctx)).WithLevel(LevelInfo)
+	base := NewFields(ctx).WithMessage("test").WithData(map[string]any{"foo": "bar", "nav": 0.1}).WithField("field", "value").WithCallTime(time.Now()).WithTraceID(trace.GetTid(ctx)).WithLevel(LevelInfo)
 	Debug(NewFields(ctx).WithBaseFields(base))
 	Debugf(NewFields(ctx).WithBaseFields(base), "test %s", "format")
 	Info(NewFields(ctx).WithBaseFields(base))

--- a/network/http/unit_test.go
+++ b/network/http/unit_test.go
@@ -3,13 +3,14 @@ package http
 import (
 	"bytes"
 	"context"
-	"github.com/alioth-center/infrastructure/utils/values"
-	"github.com/gin-gonic/gin"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/alioth-center/infrastructure/utils/values"
+	"github.com/gin-gonic/gin"
 
 	"github.com/alioth-center/infrastructure/logger"
 	"github.com/alioth-center/infrastructure/trace"

--- a/thirdparty/openai/unit_test.go
+++ b/thirdparty/openai/unit_test.go
@@ -2,13 +2,14 @@ package openai
 
 import (
 	"bytes"
-	"github.com/alioth-center/infrastructure/logger"
-	"github.com/alioth-center/infrastructure/network/http"
 	"io"
 	h "net/http"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/alioth-center/infrastructure/logger"
+	"github.com/alioth-center/infrastructure/network/http"
 )
 
 func TestOpenAiClient(t *testing.T) {
@@ -39,7 +40,6 @@ func TestOpenAiClient(t *testing.T) {
 				N: 1,
 			},
 		})
-
 		if err != nil {
 			t.Error(err)
 		}
@@ -55,7 +55,6 @@ func TestOpenAiClient(t *testing.T) {
 				Input: "Hello, world!",
 			},
 		})
-
 		if err != nil {
 			t.Error(err)
 		}


### PR DESCRIPTION
- 在 custom.go 中增加了服务字段和额外字段的环境变量注入功能。
  - 新增常量 serviceEnvKey 和 extraFieldsKey 用于环境变量键名。
  - 在 NewCustomLoggerWithOpts 函数中通过环境变量注入服务字段和额外字段。
  - 增加 attachField 逻辑，用于将注入的字段附加到日志中。
- 为 customLogger 结构体添加了 attach 字段，用于存储附加的日志字段。
  - 在 log 方法中增加了附加字段的处理逻辑。
- 在 fields.go 中增加了 WithAttachFields 方法，用于将附加字段合并到当前字段中。
  - 修改了 init 方法中的 trace.Caller 调用参数。
- 增加 WithAttachFields 选项，用于在创建 logger 实例时附加额外的字段。
- 在 unit_test.go 中增加了 TestFields 测试函数，测试环境变量注入和字段附加功能。
- 修复了 network/http 和 thirdparty/openai 的单元测试中 import 顺序问题。