### PR TITLE
feat(http): 增加模式设置功能和请求头常量定义

### DIFF
--- a/network/http/define.go
+++ b/network/http/define.go
@@ -1,5 +1,22 @@
 package http
 
+import (
+	"os"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	ModeRelease = "RELEASE"
+)
+
+var mode = os.Getenv("AC_MODE")
+
+func SetMode(m string) {
+	mode = m
+	gin.SetMode(gin.ReleaseMode)
+}
+
 const (
 	defaultTraceHeaderKey  = "Ac-Request-Id"
 	defaultErrorContextKey = "ac-error"
@@ -207,3 +224,19 @@ type FrameworkResponse struct {
 	RequestID    string `json:"request_id"`
 	Data         any    `json:"data,omitempty"`
 }
+
+type HeaderEnum = string
+
+const (
+	HeaderAuthorization  HeaderEnum = "Authorization"
+	HeaderContentType    HeaderEnum = "Content-Type"
+	HeaderUserAgent      HeaderEnum = "User-Agent"
+	HeaderAccept         HeaderEnum = "Accept"
+	HeaderEncoding       HeaderEnum = "Accept-Encoding"
+	HeaderAcceptLanguage HeaderEnum = "Accept-Language"
+	HeaderContentLength  HeaderEnum = "Content-Length"
+)
+
+type NoBody = struct{}
+
+type NoResponse = struct{}

--- a/network/http/endpoint.go
+++ b/network/http/endpoint.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
@@ -257,7 +258,11 @@ func (ep *EndPoint[request, response]) Serve(ctx *gin.Context) {
 				RequestID:    tid,
 			}
 			ctx.AbortWithStatusJSON(http.StatusInternalServerError, errResponse)
-			return
+
+			if mode != ModeRelease {
+				// recovered error should be panic with stack trace when not in release mode
+				panic(fmt.Sprintf("error: %v\nwith stack:\n%s", recovered.Error(), trace.Stack(1)))
+			}
 		}
 	}()
 


### PR DESCRIPTION
- 在 define.go 中新增了 ModeRelease 常量和 SetMode 函数，用于设置运行模式，并引入 gin 包来设置 gin 的模式。
- 定义了一些常见的 HTTP 请求头常量，如 HeaderAuthorization、HeaderContentType 等。
- 新增了 NoBody 和 NoResponse 两个空结构体类型。
- 在 endpoint.go 中修改了 Serve 函数，当非 release 模式下遇到错误时，会 panic 并打印堆栈信息。
- 在 preprocessor.go 中修改了 CheckRequestBodyPreprocessor 函数，增加了对请求体长度的检查，避免在请求体为空时进行反序列化操作。